### PR TITLE
Fix accelerate import error by updating dependencies

### DIFF
--- a/scripts/evaluate_ner.py
+++ b/scripts/evaluate_ner.py
@@ -1,0 +1,39 @@
+import os
+import torch
+from transformers import AutoTokenizer, AutoModelForTokenClassification, Trainer
+from datasets import load_dataset, load_metric
+from utils import get_label_list, tokenize_and_align_labels
+
+model_path = "models/bert-tiny-amharic" 
+label_list = get_label_list()
+num_labels = len(label_list)
+
+
+tokenizer = AutoTokenizer.from_pretrained(model_path)
+model = AutoModelForTokenClassification.from_pretrained(model_path, num_labels=num_labels)
+
+
+dataset = load_dataset("csv", data_files={"test": "./data/ner_dataset_test.csv"}, delimiter=",")
+tokenized_dataset = dataset.map(lambda x: tokenize_and_align_labels(x, tokenizer, label_list), batched=True)
+
+
+metric = load_metric("seqeval")
+
+def compute_metrics(p):
+    predictions, labels = p
+    predictions = predictions.argmax(axis=-1)
+    true_predictions = [
+        [label_list[p] for (p, l) in zip(pred, label) if l != -100]
+        for pred, label in zip(predictions, labels)
+    ]
+    true_labels = [
+        [label_list[l] for (p, l) in zip(pred, label) if l != -100]
+        for pred, label in zip(predictions, labels)
+    ]
+    results = metric.compute(predictions=true_predictions, references=true_labels)
+    return results
+
+
+trainer = Trainer(model=model)
+results = trainer.evaluate(tokenized_dataset["test"])
+print("Evaluation Results:", results)

--- a/scripts/infer_ner.py
+++ b/scripts/infer_ner.py
@@ -1,0 +1,30 @@
+from transformers import AutoTokenizer, AutoModelForTokenClassification
+import torch
+import numpy as np
+from utils import get_label_list
+
+model_path = "models/bert-tiny-amharic"  
+label_list = get_label_list()
+
+
+tokenizer = AutoTokenizer.from_pretrained(model_path)
+model = AutoModelForTokenClassification.from_pretrained(model_path)
+model.eval()
+
+
+text = "ዶክተር ሃና በአዲስ አበባ ታህሳስ 20 ወደ ብሪጃ ሆስፒታል ተማረከች።"
+
+
+inputs = tokenizer(text, return_tensors="pt", truncation=True, is_split_into_words=False)
+outputs = model(**inputs).logits
+predictions = torch.argmax(outputs, dim=2)
+
+
+tokens = tokenizer.convert_ids_to_tokens(inputs["input_ids"][0])
+pred_labels = [label_list[p.item()] for p in predictions[0]]
+
+
+print("\nNamed Entity Recognition:")
+for token, label in zip(tokens, pred_labels):
+    if label != "O":
+        print(f"{token}: {label}")


### PR DESCRIPTION
Resolved ImportError caused by missing 'accelerate' library required by HuggingFace's Trainer class. 
Installed the latest compatible version of 'accelerate>=0.26.0' to enable model training and evaluation 
with PyTorch backend.
